### PR TITLE
Fix usages of array indexes as react component array keys

### DIFF
--- a/veritable-react-gui/src/components/AgentHolder/ColumnLeft/ColumnLeftWrap/ColumnLeftWrap.js
+++ b/veritable-react-gui/src/components/AgentHolder/ColumnLeft/ColumnLeftWrap/ColumnLeftWrap.js
@@ -36,7 +36,7 @@ export default function ColumnLeftWrap({ origin }) {
 
               {dataCredentialSets.length > 0 &&
                 dataCredentialSets.map((i, k) => (
-                  <div key={k} className="card mb-3">
+                  <div key={i.referent} className="card mb-3">
                     <CredentialSetItem item={i} index={k} />
                   </div>
                 ))}

--- a/veritable-react-gui/src/components/AgentHolder/ColumnRight/ExchangeRecordsTable/ExchangeRecordsTable.js
+++ b/veritable-react-gui/src/components/AgentHolder/ColumnRight/ExchangeRecordsTable/ExchangeRecordsTable.js
@@ -17,7 +17,7 @@ export default function ExchangeRecordsTable({ dataConnRecordEvents }) {
         dataConnRecordEvents.map((o, i) => {
           const [cId, exRecordEvents] = Object.entries(o)[0]
           return (
-            <div key={i} className="my-2" id={`connection-${i}`}>
+            <div key={cId} className="my-2" id={`connection-${i}`}>
               {dataConnRecordEvents.length > 1 && (
                 <h6>
                   Events related to Connection Id <small>{cId}</small>:
@@ -28,7 +28,7 @@ export default function ExchangeRecordsTable({ dataConnRecordEvents }) {
                 exRecordEvents.map((p, j) => {
                   const [eId, events] = Object.entries(p)[0]
                   return (
-                    <div key={j} id={`wrapper-${i}-${j}`}>
+                    <div key={eId} id={`wrapper-${i}-${j}`}>
                       {events.length > 1 && (
                         <a
                           className="btn btn-dark text-left w-100"
@@ -48,7 +48,7 @@ export default function ExchangeRecordsTable({ dataConnRecordEvents }) {
                         >
                           {events.map((event, k) => (
                             <div
-                              key={k}
+                              key={`${event.pres_ex_id}:${event.updated_at}`}
                               className="table-responsive"
                               id={`table-${i}-${j}-${k}`}
                             >

--- a/veritable-react-gui/src/components/AgentIssuer/ColumnLeft/DefinitionsManager/DefinitionsManager.js
+++ b/veritable-react-gui/src/components/AgentIssuer/ColumnLeft/DefinitionsManager/DefinitionsManager.js
@@ -81,8 +81,8 @@ export default function DefinitionsManager({
               <option value="" disabled>
                 - Select -
               </option>
-              {dataDefinitionsCreated.map((d, i) => (
-                <option value={d} key={i}>
+              {dataDefinitionsCreated.map((d) => (
+                <option value={d} key={d}>
                   Definition
                   {d.split(':')[1]}.{d.split(':')[3]}.
                   {d.split(':')[4].split('.')[0]}

--- a/veritable-react-gui/src/components/AgentIssuer/ColumnLeft/SchemasManager/SchemasManager.js
+++ b/veritable-react-gui/src/components/AgentIssuer/ColumnLeft/SchemasManager/SchemasManager.js
@@ -72,8 +72,8 @@ export default function SchemasManager({
               <option value="" disabled>
                 - Select -
               </option>
-              {dataSchemasCreated.map((s, i) => (
-                <option value={s} key={i}>
+              {dataSchemasCreated.map((s) => (
+                <option value={s} key={s}>
                   FlySchemaV{s.split(':')[3]}
                 </option>
               ))}

--- a/veritable-react-gui/src/components/AgentIssuer/ColumnRight/ColumnRightWrap/ColumnRightWrap.js
+++ b/veritable-react-gui/src/components/AgentIssuer/ColumnRight/ColumnRightWrap/ColumnRightWrap.js
@@ -37,7 +37,7 @@ export default function ColumnRightWrap({ origin }) {
                 )}
 
                 {dataRecords.map((r, i) => (
-                  <div key={i} className="card">
+                  <div key={r.cred_ex_record.cred_ex_id} className="card">
                     <IssuedRecordItem record={r} index={i} />
                   </div>
                 ))}

--- a/veritable-react-gui/src/components/AgentVerifier/ColumnLeft/VerifyPresentationManager/VerifyPresentationManager.js
+++ b/veritable-react-gui/src/components/AgentVerifier/ColumnLeft/VerifyPresentationManager/VerifyPresentationManager.js
@@ -37,8 +37,8 @@ export default function VerifyPresentationManager({
               <option value={''} disabled>
                 - Select -
               </option>
-              {dataPresExIds.map((e, i) => (
-                <option value={e} key={i}>
+              {dataPresExIds.map((e) => (
+                <option value={e} key={e}>
                   {e}
                 </option>
               ))}

--- a/veritable-react-gui/src/components/AgentVerifier/ColumnRight/ExchangeRecords/ExchangeRecords.js
+++ b/veritable-react-gui/src/components/AgentVerifier/ColumnRight/ExchangeRecords/ExchangeRecords.js
@@ -19,7 +19,7 @@ export default function ExchangeRecords({ dataConnRecordEvents }) {
         dataConnRecordEvents.map((o, i) => {
           const [cId, exRecordEvents] = Object.entries(o)[0]
           return (
-            <div key={i} className="text-dark" id={`connection-${i}`}>
+            <div key={cId} className="text-dark" id={`connection-${i}`}>
               {dataConnRecordEvents.length > 1 && (
                 <h6>
                   Events related to Connection Id <small>{cId}</small>:
@@ -32,7 +32,7 @@ export default function ExchangeRecords({ dataConnRecordEvents }) {
                   return (
                     <div
                       className="bg-light mb-2"
-                      key={j}
+                      key={eId}
                       id={`wrapper-${i}-${j}`}
                     >
                       <a
@@ -52,7 +52,7 @@ export default function ExchangeRecords({ dataConnRecordEvents }) {
                           <div className="accordion" id={`accordion-${i}-${j}`}>
                             {events.map((event, k) => (
                               <div
-                                key={k}
+                                key={`${event.pres_ex_id}:${event.updated_at}`}
                                 className="card border border-bottom-1"
                               >
                                 <Event i={i} j={j} k={k} event={event} />

--- a/veritable-react-gui/src/components/Common/Navigation/Connectivity/ConnectionAvatar/ConnectionAvatar.js
+++ b/veritable-react-gui/src/components/Common/Navigation/Connectivity/ConnectionAvatar/ConnectionAvatar.js
@@ -57,9 +57,9 @@ export default function ConnectionAvatar({ data, onDelete }) {
     <>
       {data?.results
         ?.filter((d) => d.state === 'active')
-        .map((c, k) => {
+        .map((c) => {
           return (
-            <li key={k} className="nav-item small">
+            <li key={c.connection_id} className="nav-item small">
               <div className="btn-group">
                 <a
                   className="p-1 m-1 text-primary bg-light"
@@ -100,9 +100,9 @@ export default function ConnectionAvatar({ data, onDelete }) {
                         </div>
                       </li>
 
-                      {arrReduceEntries(c).map(([key, val], index) => (
+                      {arrReduceEntries(c).map(([key, val]) => (
                         <li
-                          key={index}
+                          key={key}
                           className="list-group-item small text-break"
                         >
                           <div className="row">

--- a/veritable-react-gui/src/components/Common/Navigation/Connectivity/Connections/Connections.js
+++ b/veritable-react-gui/src/components/Common/Navigation/Connectivity/Connections/Connections.js
@@ -25,7 +25,7 @@ export default function Connections({ data }) {
           const s = c.state
           const _ = c.connection_id.split('-')
           return (
-            <li key={i} className="list-group-item small p-1">
+            <li key={c.connection_id} className="list-group-item small p-1">
               <small>{i} | &nbsp;</small>
               <small>{t} | &nbsp;</small>
               <small>{r} | &nbsp;</small>


### PR DESCRIPTION
These fixes are mostly pretty obvious. Couple for reviwers to consider specifically:

* `ColumnLeftWrap.js` uses `referent` as the key. I think this is correct based on documentation in the indy-sdk https://hyperledger-indy.readthedocs.io/projects/sdk/en/latest/docs/design/002-anoncreds/README.html 
* The deepest exchange records event type doesn't have a obvious primary key so I've used                               `${event.pres_ex_id}:${event.updated_at}`. This is likely ok at a practical level but isn't ideal
* `ColumnRightWrap` uses `r.cred_ex_record.cred_ex_id` as a key which based on usage elsewhere looks correct