### PR TITLE
Bug - Authority label

### DIFF
--- a/docker/docker-compose.yaml
+++ b/docker/docker-compose.yaml
@@ -107,7 +107,7 @@ services:
     env_file: ./AriesCloudAgentCommon.env
     environment:
       - ACAPY_ENDPOINT=http://veritable-cloudagent-regulator:8000
-      - ACAPY_LABEL=regulator.agent
+      - ACAPY_LABEL=authority.agent
       - ACAPY_WALLET_NAME=regulator
       - ACAPY_WALLET_KEY=regulator_password
       - ACAPY_WALLET_SEED=000000000000000000000000000Node2


### PR DESCRIPTION
Steps to reproduce:
Run `start.sh`
Every refresh of `veritable-holder` front-end on `localhost:3001` causes it to create a new connection to `authority` cloudagent.

Reason:
`veritable-holder` `AUTHORITY_LABEL` env is still `authority`. The `holder` auto-connect to `authority` checks existing connection labels against the env and they aren't matching (because the cloudagent label is `regulator`).

Solution:
Rather than change `veritable-holder` env, change the cloudagent label back to `authority` for now until someone is fully working on https://digicatapult.atlassian.net/browse/F2P-77

